### PR TITLE
switch to `getLoaderConfig` to prevent option JSON serialization

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ const pug = require('pug')
 
 module.exports = function (source) {
   this.cacheable && this.cacheable()
-  let query = util.parseQuery(this.query)
+  let query = util.getLoaderConfig(this, 'pug-html')
   let req = util.getRemainingRequest(this)
   let options = Object.assign({
     filename: this.resourcePath,


### PR DESCRIPTION
This mirrors the commit at `pug-loader` [here](https://github.com/pugjs/pug-loader/commit/661ac5360b0976fe11d03de23ec1303dca3259e8). The point here is to enable passing functions as options, which appears to be the intended approach to extend Pug through plugins; see [this thread](https://github.com/pugjs/pug-lexer/pull/69#issuecomment-240638162).
