### PR TITLE
Allow pug-html-loader to work with html-loader

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,5 @@ module.exports = function (source) {
     compileDebug: this.debug || false
   }, query)
   let content = pug.compile(source, options)(query)
-  this.value = content
-  return `module.exports = ${JSON.stringify(content)};`
+  return `module.exports = ${content};`
 }


### PR DESCRIPTION
This change allows something like `require('html!pug-html!./template.pug')` to work. The reasoning behind this is so that html-loader can be used to handle assets among other things.

"Stringifying" the compiled template is causing html-loader to fail to parse `src` attributes properly, as they are being output as escaped JS strings. This is required to allow for integration with image and asset loaders.
