### PR TITLE
Substitution Rules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,10 +3,25 @@
   Author Williams Medina @willyelm
 */
 'use strict'
-const util = require('loader-utils')
-const pug = require('pug')
+const util = require('loader-utils');
+const path = require('path');
+const pug = require('pug');
 
 module.exports = function (source) {
+
+  const applySubstitutionRules = (data) => {
+    for (var key in data) {
+      if (typeof data[key] === 'string') {
+        data[key] = data[key]
+          .replace('[templatename]', path.basename(this.resourcePath, '.pug'))
+          .replace('[templatepath]', this.resourcePath)
+      } else if (Object.keys(data[key]).length > 0) {
+        data[key] = applySubstitutionRules(data[key]);
+      }
+    }
+
+    return data;
+  };
 
   if (this.cacheable) {
     this.cacheable(true)
@@ -21,6 +36,10 @@ module.exports = function (source) {
   }, query)
   let template = pug.compile(source, options)
   let data = query.data || {}
+
+
+  data = applySubstitutionRules(data);
+
   let html = template(data)
   if (query.exports === false) {
     return html


### PR DESCRIPTION
added substitution rules so that [templatename] and [templatepath] get substituted with their values when used in query data.

This way, you can do the following:

```
{
        test: /\.pug/,
        include: path.join(__dirname, 'templates'),
        loader: 'pug-html-loader',
        query: {
          data: {
            widgetName: '[templatename]',
            totalWidgets: 20
          },
          doctype: 'html',
          pretty: true
        }
      }
```

If you run this against `foo.pug`, `bar.pug` and `bang.pug`, then `#{widgetName}` in those files will resolve to 'foo', 'bar' and 'bang', respectively.

It would really make my day if, if you like this, you could merge and publish a new version, like, today. If you don't, no sweat, I'll fork. :)