### PR TITLE
#23 - Load Config with getLoaderConfig

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,15 +7,10 @@ const util = require('loader-utils')
 const pug = require('pug')
 
 module.exports = function (source) {
-  let query = {}
   if (this.cacheable) {
     this.cacheable(true)
   }
-  if (typeof this.query === 'string') {
-    query = util.parseQuery(this.query)
-  } else {
-    query = this.query
-  }
+  let query = loaderUtils.getLoaderConfig(this, "pugHtmlLoader") || {};
   let req = util.getRemainingRequest(this)
   let options = Object.assign({
     filename: this.resourcePath,


### PR DESCRIPTION
Adds support to optionally set the loader `query` options via your webpack config, add a key `pugHtmlLoader`:

Hopefully addresses #23 
:crossed_fingers: 

```js

module.exports = {
// Option 1: 
  pugHtmlLoader: {
    pretty: true,
    data: { name: 'Pugly' }
  },
  module: [
    // your modules...
    loaders: [{
      include: /\.pug$/,
// Option 2: pass options to pug as a query ('pug-html-loader?pretty')
      loaders: ['html-loader', 'pug-html-loader?pretty=true&data={name:"Pugly"}']
    }]
  ]
};

```

Both options can be set, and if so, they will be deep merged.