### PR TITLE
🔧 Change plugins to expect array of objects

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,13 +23,8 @@ module.exports = function (source) {
     compileDebug: this.debug || false
   }, query)
   if (options.plugins){
-    if (typeof options.plugins === 'string') {
+    if (typeof options.plugins === 'object') {
       options.plugins = [options.plugins];
-    }
-    if (Array.isArray(options.plugins)) {
-      options.plugins = options.plugins.map(function (plugin) {
-        return require(plugin);
-      });
     }
   }
   let template = pug.compile(source, options)


### PR DESCRIPTION
This PR fixes the plugins signature to expect an array of objects, matching the Pug options API.

This allows user to pass arguments to the plugin:
```
...
{
  loader: 'pug-html-loader',
  options: {
    plugins: [
      myCustomPlugin(options),
      myOtherPlugin(),
      {  // or you could even inline a plugin here
        resolve(filename, source, options) {...}
      }
    ]
  }
},
...
```

You could also pass in pluggable override hooks in an object and `pug-html-loader` will wrap them into an array to pass to Pug as plugins:

```
...
{
  loader: 'pug-html-loader',
  options: {
    plugins: {
      resolve(filename, source, options) {...},
      lex() {...}
    }
  }
},
...
```

This also matches the webpack signature for plugins, providing additional familiarity.