### PR TITLE
Fix the plugins option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ module.exports = function (source) {
     compileDebug: this.debug || false
   }, query)
   if (options.plugins){
-    if (typeof options.plugins === 'object') {
+    if (!(options.plugins instanceof Array)) {
       options.plugins = [options.plugins];
     }
   }


### PR DESCRIPTION
In the previous code: `typeof options.plugins === 'object'` would result in `true` so it was wrapping an array around the original options.plugins array.