### PR TITLE
Fix watch mode for pug files with errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,8 @@
 const util = require('loader-utils')
 const pug = require('pug')
 
+let cachedDeps;
+
 module.exports = function (source) {
   let query = {}
   if (this.cacheable) {
@@ -27,7 +29,15 @@ module.exports = function (source) {
       options.plugins = [options.plugins];
     }
   }
-  let template = pug.compile(source, options)
+  let template;
+  try {
+    template = pug.compile(source, options);
+  } catch (ex) {
+    cachedDeps.forEach(this.addDependency);
+    this.callback(ex);
+    return;
+  }
+  cachedDeps = template.dependencies ? template.dependencies.slice() : undefined;
   template.dependencies.forEach(this.addDependency)
   let data = query.data || {}
   return template(data)


### PR DESCRIPTION
Whenever compilation fails due to a pug syntax error, webpack watch mode stops tracking files. This PR fixes that by caching dependencies and adding them in case of compilation error.