### PR TITLE
The HTML output problem is fixed which gives result like <!DOCTYPE js>.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,10 +19,10 @@ module.exports = function (source) {
   let req = util.getRemainingRequest(this)
   let options = Object.assign({
     filename: this.resourcePath,
-    doctype: query.doctype || 'js',
+    doctype: query.doctype || 'html',
     compileDebug: this.debug || false
   }, query)
-  if (options.plugins){
+  if (options.plugins) {
     if (!(options.plugins instanceof Array)) {
       options.plugins = [options.plugins];
     }


### PR DESCRIPTION
When I compile the pug file via webpack, output file has a usual doctype like <!DOCTYPE js> .

doctype must have "HTML" as the default value. 